### PR TITLE
Fixed typo ehere -> where

### DIFF
--- a/CS241e.md
+++ b/CS241e.md
@@ -394,7 +394,7 @@ if (e1, op, e2, then, else) => {
 
 Procedures: an abstraction that encapsulates a reusable sequence of code
 - calling code and procedure agree on conventions
-  - ehere (memory/registers) to pass arguments and return value
+  - where (memory/registers) to pass arguments and return value
   - which registers procedures may modify (caller-save) or preserve (callee-save)
 - calling code **transfers control** to the procedure (modifies PC)
 - calling code passes arguments for parameters


### PR DESCRIPTION
Change typo in CS241e notes. Changed ehere to where.
